### PR TITLE
replyParser had a bug where, when a base64 address ended with '==', t…

### DIFF
--- a/replyParser.go
+++ b/replyParser.go
@@ -50,7 +50,8 @@ func parseReply(line string) (*Reply, error) {
 	}
 
 	for _, v := range parts[2:] {
-		kvPair := strings.Split(v, "=")
+        kvPair := strings.Split(strings.Replace(v, "==", "%", -1), "=")
+        kvPair[1] = strings.Replace(kvPair[1], "%", "==", -1)
 		if len(kvPair) != 2 {
 			return nil, fmt.Errorf("Malformed key-value-pair.\n%s\n", kvPair)
 		}

--- a/replyParser.go
+++ b/replyParser.go
@@ -50,8 +50,7 @@ func parseReply(line string) (*Reply, error) {
 	}
 
 	for _, v := range parts[2:] {
-        kvPair := strings.Split(strings.Replace(v, "==", "%", -1), "=")
-        kvPair[1] = strings.Replace(kvPair[1], "%", "==", -1)
+		kvPair := strings.SplitN(v, "=", 2)
 		if len(kvPair) != 2 {
 			return nil, fmt.Errorf("Malformed key-value-pair.\n%s\n", kvPair)
 		}

--- a/replyParser_test.go
+++ b/replyParser_test.go
@@ -33,6 +33,19 @@ var validCases = []struct {
 			},
 		},
 	},
+	// result of a b32.i2p naming lookup
+	{
+		"NAMING REPLY RESULT=OK NAME=gkso46tc47hdua2kva5zahj3unmyh6ia7bv5oc2ybn2hmeowpz7a.b32.i2p VALUE=mlHQraXLpcE7A4MVeVniRHM~2yoaW1fOYVKj3ZiNTe4UPIAlIReYUMHSnZnloFWX7bh2OoEg08JBGoSQPtGkCZjqSBmfeDdMqtwbZ~~sok-jNo4e5rWnfCOHYYPVcuE8jB~7M5ioJzk8QZRqh3AjCQsKBUZgTzUfGlP12j3GtAf5C9iAGxTTB1sGE96752EKP0dzyGOs4NAujwkgm6NzVoqlkXD~fognUrQOeG~~OqChsAeqIRqj40FsJmsJREmZ4GhjFAqzLUQ4hMpKSbqMI~wtfjeNs-WKtM7pCD09uwSmYwW84wu-WxLGZiIt2GKmbPv~JrqYFNv9EM0SzUonAF8pw9GAhUn8-26kkgCXTs05Kut7NuQHghu3jHfS-frlPmAt-Uu5T4ZcLiHiFrnG2lYTtjxBFXh7W72IBncHSixhVhd4lYM7REKFj7G~5ttW9EBeL1unbNYWiQOEQjtGlmwxYt~~2EV16w339aQQ~S~69-tS6vFA1n2DgkMdg06pBQAEAAEAAA==\n",
+		Reply{
+			Topic: "NAMING",
+			Type:  "REPLY",
+			Pairs: map[string]string{
+				"RESULT": "OK",
+				"NAME":   "gkso46tc47hdua2kva5zahj3unmyh6ia7bv5oc2ybn2hmeowpz7a.b32.i2p",
+				"VALUE":  "mlHQraXLpcE7A4MVeVniRHM~2yoaW1fOYVKj3ZiNTe4UPIAlIReYUMHSnZnloFWX7bh2OoEg08JBGoSQPtGkCZjqSBmfeDdMqtwbZ~~sok-jNo4e5rWnfCOHYYPVcuE8jB~7M5ioJzk8QZRqh3AjCQsKBUZgTzUfGlP12j3GtAf5C9iAGxTTB1sGE96752EKP0dzyGOs4NAujwkgm6NzVoqlkXD~fognUrQOeG~~OqChsAeqIRqj40FsJmsJREmZ4GhjFAqzLUQ4hMpKSbqMI~wtfjeNs-WKtM7pCD09uwSmYwW84wu-WxLGZiIt2GKmbPv~JrqYFNv9EM0SzUonAF8pw9GAhUn8-26kkgCXTs05Kut7NuQHghu3jHfS-frlPmAt-Uu5T4ZcLiHiFrnG2lYTtjxBFXh7W72IBncHSixhVhd4lYM7REKFj7G~5ttW9EBeL1unbNYWiQOEQjtGlmwxYt~~2EV16w339aQQ~S~69-tS6vFA1n2DgkMdg06pBQAEAAEAAA==",
+			},
+		},
+	},
 	// session status reply
 	{
 		"SESSION STATUS RESULT=I2P_ERROR MESSAGE=TheMessageFromI2p\n",


### PR DESCRIPTION
…he key-value pairs would break. I worked around the issue by switching '==' it with a non-base64 character before the split, and back after. I'm basically an amateur, hopefully that's an acceptable way to deal with that.