### PR TITLE
Added a nil check in replyParser.go

### DIFF
--- a/replyParser.go
+++ b/replyParser.go
@@ -51,9 +51,12 @@ func parseReply(line string) (*Reply, error) {
 
 	for _, v := range parts[2:] {
 		kvPair := strings.SplitN(v, "=", 2)
-		if len(kvPair) != 2 {
-			return nil, fmt.Errorf("Malformed key-value-pair.\n%s\n", kvPair)
+		if kvPair != nil {
+			if len(kvPair) != 2 {
+				return nil, fmt.Errorf("Malformed key-value-pair.\n%s\n", kvPair)
+			}
 		}
+
 		r.Pairs[kvPair[0]] = kvPair[1]
 	}
 


### PR DESCRIPTION
I don't know exactly why, but checking that the kvPair in replyParser is not nil fixes a segmentation fault I get when some requests fail in some ways. I think that what is happening is that the 's' string passed to strings.SplitN is empty in some of those requests, which returns a result who's behavior doesn't seem to be [immediately apparent from my usual source of documentation](https://golang.org/pkg/strings/#Split)(it says what happens when sep is empty, but not s), but which seems to be detectable by adding a nil check around the len(kvPair) == 2 check.