### PR TITLE
Configurable host:port 

### DIFF
--- a/accept.go
+++ b/accept.go
@@ -21,7 +21,7 @@ func (c *Client) Accept() (net.Conn, error) {
 		return nil, err
 	}
 
-	if ConnDebug {
+	if c.debug {
 		newC.SamConn = debug.WrapConn(newC.SamConn)
 	}
 

--- a/client.go
+++ b/client.go
@@ -16,6 +16,10 @@ type Client struct {
 	SamConn net.Conn
 	rd      *bufio.Reader
 
+    inLength uint
+
+    outLength uint
+
 	debug bool
 }
 

--- a/client.go
+++ b/client.go
@@ -41,7 +41,9 @@ func NewClientFromOptions(opts ...func(*Client) error) (*Client, error) {
 	c.addr = "127.0.0.1"
 	c.port = "7656"
     c.inLength = 3
+    c.inVariance = 0
 	c.outLength = 3
+	c.outVariance = 0
 	c.debug = false
 	for _, o := range opts {
 		if err := o(&c); err != nil {

--- a/client.go
+++ b/client.go
@@ -42,7 +42,7 @@ func NewClient(addr string) (*Client, error) {
 	return NewClientFromOptions(SetAddr(addr))
 }
 
-// NewClientFromOptionss creates a new client, connecting to a specified port
+// NewClientFromOptions creates a new client, connecting to a specified port
 func NewClientFromOptions(opts ...func(*Client) error) (*Client, error) {
 	var c Client
 	c.addr = "127.0.0.1"

--- a/client.go
+++ b/client.go
@@ -82,7 +82,7 @@ func (c *Client) samaddr() string {
 
 // send the initial handshake command and check that the reply is ok
 func (c *Client) hello() error {
-	r, err := c.sendCmd("HELLO VERSION MIN=3.0 MAX=3.0\n")
+	r, err := c.sendCmd("HELLO VERSION MIN=3.0 MAX=3.0\n", c.allOptions())
 	if err != nil {
 		return err
 	}

--- a/client.go
+++ b/client.go
@@ -16,9 +16,11 @@ type Client struct {
 	SamConn net.Conn
 	rd      *bufio.Reader
 
-    inLength uint
+	inLength uint
+    inVariance int
 
-    outLength uint
+	outLength uint
+    outVariance int
 
 	debug bool
 }
@@ -38,6 +40,8 @@ func NewClientFromOptions(opts ...func(*Client) error) (*Client, error) {
 	var c Client
 	c.addr = "127.0.0.1"
 	c.port = "7656"
+    c.inLength = 3
+	c.outLength = 3
 	c.debug = false
 	for _, o := range opts {
 		if err := o(&c); err != nil {

--- a/client.go
+++ b/client.go
@@ -26,6 +26,8 @@ type Client struct {
     outQuantity uint
     outBackups uint
 
+    dontPublishLease bool
+	encryptLease     bool
 
 	debug bool
 }
@@ -53,6 +55,8 @@ func NewClientFromOptions(opts ...func(*Client) error) (*Client, error) {
 	c.outVariance = 0
     c.outQuantity = 4
     c.outBackups = 2
+    c.dontPublishLease = true
+	c.encryptLease = false
 	c.debug = false
 	for _, o := range opts {
 		if err := o(&c); err != nil {

--- a/client.go
+++ b/client.go
@@ -16,17 +16,17 @@ type Client struct {
 	SamConn net.Conn
 	rd      *bufio.Reader
 
-	inLength uint
-    inVariance int
-    inQuantity uint
-    inBackups uint
+	inLength   uint
+	inVariance int
+	inQuantity uint
+	inBackups  uint
 
-	outLength uint
-    outVariance int
-    outQuantity uint
-    outBackups uint
+	outLength   uint
+	outVariance int
+	outQuantity uint
+	outBackups  uint
 
-    dontPublishLease bool
+	dontPublishLease bool
 	encryptLease     bool
 
 	debug bool
@@ -47,15 +47,15 @@ func NewClientFromOptions(opts ...func(*Client) error) (*Client, error) {
 	var c Client
 	c.addr = "127.0.0.1"
 	c.port = "7656"
-    c.inLength = 3
-    c.inVariance = 0
-    c.inQuantity = 4
-    c.inBackups = 2
+	c.inLength = 3
+	c.inVariance = 0
+	c.inQuantity = 4
+	c.inBackups = 2
 	c.outLength = 3
 	c.outVariance = 0
-    c.outQuantity = 4
-    c.outBackups = 2
-    c.dontPublishLease = true
+	c.outQuantity = 4
+	c.outBackups = 2
+	c.dontPublishLease = true
 	c.encryptLease = false
 	c.debug = false
 	for _, o := range opts {

--- a/client.go
+++ b/client.go
@@ -19,10 +19,13 @@ type Client struct {
 	inLength uint
     inVariance int
     inQuantity uint
+    inBackups uint
 
 	outLength uint
     outVariance int
     outQuantity uint
+    outBackups uint
+
 
 	debug bool
 }
@@ -45,9 +48,11 @@ func NewClientFromOptions(opts ...func(*Client) error) (*Client, error) {
     c.inLength = 3
     c.inVariance = 0
     c.inQuantity = 4
+    c.inBackups = 2
 	c.outLength = 3
 	c.outVariance = 0
     c.outQuantity = 4
+    c.outBackups = 2
 	c.debug = false
 	for _, o := range opts {
 		if err := o(&c); err != nil {

--- a/client.go
+++ b/client.go
@@ -10,7 +10,7 @@ import (
 
 // A Client represents a single Connection to the SAM bridge
 type Client struct {
-	addr string
+	host string
 	port string
 
 	SamConn net.Conn
@@ -45,7 +45,7 @@ func NewClient(addr string) (*Client, error) {
 // NewClientFromOptions creates a new client, connecting to a specified port
 func NewClientFromOptions(opts ...func(*Client) error) (*Client, error) {
 	var c Client
-	c.addr = "127.0.0.1"
+	c.host = "127.0.0.1"
 	c.port = "7656"
 	c.inLength = 3
 	c.inVariance = 0
@@ -75,9 +75,9 @@ func NewClientFromOptions(opts ...func(*Client) error) (*Client, error) {
 	return &c, c.hello()
 }
 
-//return the combined addr:port of the SAM bridge
+//return the combined host:port of the SAM bridge
 func (c *Client) samaddr() string {
-	return fmt.Sprintf("%s:%s", c.addr, c.port)
+	return fmt.Sprintf("%s:%s", c.host, c.port)
 }
 
 // send the initial handshake command and check that the reply is ok

--- a/client.go
+++ b/client.go
@@ -18,9 +18,11 @@ type Client struct {
 
 	inLength uint
     inVariance int
+    inQuantity uint
 
 	outLength uint
     outVariance int
+    outQuantity uint
 
 	debug bool
 }
@@ -42,8 +44,10 @@ func NewClientFromOptions(opts ...func(*Client) error) (*Client, error) {
 	c.port = "7656"
     c.inLength = 3
     c.inVariance = 0
+    c.inQuantity = 4
 	c.outLength = 3
 	c.outVariance = 0
+    c.outQuantity = 4
 	c.debug = false
 	for _, o := range opts {
 		if err := o(&c); err != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -7,10 +7,8 @@ var client *Client
 func setup(t *testing.T) {
 	var err error
 
-	ConnDebug = true
-
 	// these tests expect a running SAM brige on this address
-	client, err = NewDefaultClient()
+	client, err = NewClientFromOptions(SetDebug(true))
 	if err != nil {
 		t.Fatalf("NewDefaultClient() Error: %q\n", err)
 	}

--- a/dial.go
+++ b/dial.go
@@ -21,7 +21,7 @@ func (c *Client) Dial(network, addr string) (net.Conn, error) {
 		return nil, err
 	}
 
-	newC, err := NewDefaultClient()
+	newC, err := NewClient(c.samaddr())
 	if err != nil {
 		return nil, err
 	}

--- a/example/httpTest.go
+++ b/example/httpTest.go
@@ -10,7 +10,8 @@ import (
 )
 
 func main() {
-	goSam.ConnDebug = true
+	//In order to enable debugging, pass the SetDebug(true) option.
+    //sam, err := goSam.NewClientFromOptions(SetDebug(true))
 
 	// create a default sam client
 	sam, err := goSam.NewDefaultClient()

--- a/naming_test.go
+++ b/naming_test.go
@@ -11,7 +11,7 @@ func TestClientLookupInvalid(t *testing.T) {
 	setup(t)
 	defer teardown(t)
 
-	addr, err := client.Lookup("abci2p")
+	addr, err := client.Lookup("abc.i2p")
 	if addr != "" || err == nil {
 		t.Error("client.Lookup() should throw an error.")
 	}

--- a/naming_test.go
+++ b/naming_test.go
@@ -11,7 +11,7 @@ func TestClientLookupInvalid(t *testing.T) {
 	setup(t)
 	defer teardown(t)
 
-	addr, err := client.Lookup("abc.i2p")
+	addr, err := client.Lookup("abci2p")
 	if addr != "" || err == nil {
 		t.Error("client.Lookup() should throw an error.")
 	}

--- a/options.go
+++ b/options.go
@@ -17,7 +17,7 @@ func SetAddr(s ...string) func(*Client) error {
 			if len(split) == 2 {
 				if i, err := strconv.Atoi(split[1]); err == nil {
 					if i < 65536 {
-						c.addr = split[0]
+						c.host = split[0]
 						c.port = split[1]
 						return nil
 					}
@@ -29,7 +29,7 @@ func SetAddr(s ...string) func(*Client) error {
 		} else if len(s) == 2 {
 			if i, err := strconv.Atoi(s[1]); err == nil {
 				if i < 65536 {
-					c.addr = s[0]
+					c.host = s[0]
 					c.port = s[1]
 					return nil
 				}
@@ -46,7 +46,7 @@ func SetAddr(s ...string) func(*Client) error {
 func SetAddrMixed(s string, i int) func(*Client) error {
 	return func(c *Client) error {
 		if i < 65536 && i > 0 {
-			c.addr = s
+			c.host = s
 			c.port = strconv.Itoa(i)
 			return nil
 		}
@@ -57,7 +57,7 @@ func SetAddrMixed(s string, i int) func(*Client) error {
 //SetHost sets the host of the client's SAM bridge
 func SetHost(s string) func(*Client) error {
 	return func(c *Client) error {
-		c.addr = s
+		c.host = s
 		return nil
 	}
 }

--- a/options.go
+++ b/options.go
@@ -124,6 +124,28 @@ func SetOutLength(u uint) func(*Client) error {
 	}
 }
 
+func SetInVariance(i int) func(*Client) error {
+	return func(c *Client) error {
+		if i < 7 && i > -7 {
+			c.inVariance = i
+			return nil
+		} else {
+			return fmt.Errorf("Invalid inbound tunnel length")
+		}
+	}
+}
+
+func SetOutVariance(i int) func(*Client) error {
+	return func(c *Client) error {
+		if i < 7 && i > -7 {
+			c.outVariance = i
+			return nil
+		} else {
+			return fmt.Errorf("Invalid outbound tunnel variance")
+		}
+	}
+}
+
 //return the inbound length as a string.
 func (c *Client) inlength() string {
 	return "inbound.length=" + fmt.Sprint(c.inLength)
@@ -134,10 +156,22 @@ func (c *Client) outlength() string {
 	return "outbound.length=" + fmt.Sprint(c.outLength)
 }
 
+//return the inbound length variance as a string.
+func (c *Client) invariance() string {
+	return "inbound.lengthVariance=" + fmt.Sprint(c.inVariance)
+}
+
+//return the outbound length variance as a string.
+func (c *Client) outvariance() string {
+	return "outbound.lengthVariance=" + fmt.Sprint(c.outVariance)
+}
+
 //return all options as string array ready for passing to sendcmd
 func (c *Client) allOptions() []string {
 	var options []string
 	options = append(options, c.inlength())
 	options = append(options, c.outlength())
+    options = append(options, c.invariance())
+	options = append(options, c.outvariance())
 	return options
 }

--- a/options.go
+++ b/options.go
@@ -10,52 +10,50 @@ import (
 type Option func(*Client) error
 
 //SetAddr sets a clients's address in the form host:port or host, port
-func SetAddr(s ...interface{}) func(*Client) error {
+func SetAddr(s ...string) func(*Client) error {
 	return func(c *Client) error {
 		if len(s) == 1 {
-			switch v := s[0].(type) {
-			case string:
-				split := strings.SplitN(v, ":", 2)
-				if len(split) == 2 {
-					if i, err := strconv.Atoi(split[1]); err == nil {
-						if i < 65536 {
-							c.addr = split[0]
-							c.port = split[1]
-							return nil
-						}
-						return fmt.Errorf("Invalid port")
-					}
-					return fmt.Errorf("Invalid port; non-number")
-				}
-				return fmt.Errorf("Invalid address; use host:port", split)
-			default:
-				return fmt.Errorf("Invalid address; address must be string")
-			}
-		} else if len(s) == 2 {
-			switch v := s[1].(type) {
-			case int:
-				if v < 65536 {
-					c.addr = s[0].(string)
-					c.port = strconv.Itoa(v)
-					return nil
-				}
-				return fmt.Errorf("Invalid port")
-			case string:
-				if i, err := strconv.Atoi(s[1].(string)); err == nil {
+			split := strings.SplitN(s[0], ":", 2)
+			if len(split) == 2 {
+				if i, err := strconv.Atoi(split[1]); err == nil {
 					if i < 65536 {
-						c.addr = s[0].(string)
-						c.port = s[1].(string)
+						c.addr = split[0]
+						c.port = split[1]
 						return nil
 					}
 					return fmt.Errorf("Invalid port")
 				}
 				return fmt.Errorf("Invalid port; non-number")
-			default:
-				return fmt.Errorf("Invalid port; non-number")
 			}
+			return fmt.Errorf("Invalid address; use host:port %s", split)
+		} else if len(s) == 2 {
+			if i, err := strconv.Atoi(s[1]); err == nil {
+				if i < 65536 {
+					c.addr = s[0]
+					c.port = s[1]
+					return nil
+				}
+				return fmt.Errorf("Invalid port")
+			}
+			return fmt.Errorf("Invalid port; non-number")
 		} else {
 			return fmt.Errorf("Invalid address")
 		}
+	}
+}
+
+//SetAddrMixed sets a clients's address in the form host:port or host, port
+func SetAddrMixed(s string, i int) func(*Client) error {
+	return func(c *Client) error {
+		if i, err := strconv.Atoi(s); err == nil {
+			if i < 65536 {
+				c.addr = s
+				c.port = strconv.Itoa(i)
+				return nil
+			}
+			return fmt.Errorf("Invalid port")
+		}
+		return fmt.Errorf("Invalid port; non-number")
 	}
 }
 
@@ -67,29 +65,29 @@ func SetHost(s string) func(*Client) error {
 	}
 }
 
-//SetPort sets the port of the client's SAM bridge
-func SetPort(s interface{}) func(*Client) error {
+//SetPort sets the port of the client's SAM bridge using a string
+func SetPort(s string) func(*Client) error {
 	return func(c *Client) error {
-		switch v := s.(type) {
-		case string:
-			port, err := strconv.Atoi(v)
-			if err != nil {
-				return fmt.Errorf("Invalid port; non-number")
-			}
-			if port < 65536 && port > -1 {
-				c.port = v
-				return nil
-			}
-			return fmt.Errorf("Invalid port")
-		case int:
-			if v < 65536 && v > -1 {
-				c.port = strconv.Itoa(v)
-				return nil
-			}
-			return fmt.Errorf("Invalid port")
-		default:
-			return fmt.Errorf("Invalid port")
+		port, err := strconv.Atoi(s)
+		if err != nil {
+			return fmt.Errorf("Invalid port; non-number")
 		}
+		if port < 65536 && port > -1 {
+			c.port = s
+			return nil
+		}
+		return fmt.Errorf("Invalid port")
+	}
+}
+
+//SetPortInt sets the port of the client's SAM bridge using a string
+func SetPortInt(i int) func(*Client) error {
+	return func(c *Client) error {
+		if i < 65536 && i > -1 {
+			c.port = strconv.Itoa(i)
+			return nil
+		}
+		return fmt.Errorf("Invalid port")
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -141,4 +141,3 @@ func (c *Client) allOptions() []string {
 	options = append(options, c.outlength())
 	return options
 }
-

--- a/options.go
+++ b/options.go
@@ -265,13 +265,13 @@ func (c *Client) allOptions() []string {
 	var options []string
 	options = append(options, c.inlength())
 	options = append(options, c.outlength())
-    options = append(options, c.invariance())
+	options = append(options, c.invariance())
 	options = append(options, c.outvariance())
-    options = append(options, c.inquantity())
+	options = append(options, c.inquantity())
 	options = append(options, c.outquantity())
-    options = append(options, c.inbackups())
+	options = append(options, c.inbackups())
 	options = append(options, c.outbackups())
-    options = append(options, c.dontpublishlease())
+	options = append(options, c.dontpublishlease())
 	options = append(options, c.encryptlease())
 	return options
 }

--- a/options.go
+++ b/options.go
@@ -8,7 +8,6 @@ import (
 
 type Option func(*Client) error
 
-
 //SetAddr sets a clients's address in the form host:port or host, port
 func SetAddr(s ...interface{}) func(*Client) error {
 	return func(c *Client) error {
@@ -62,7 +61,6 @@ func SetAddr(s ...interface{}) func(*Client) error {
 		return nil
 	}
 }
-
 
 //SetHost sets the host of the client's SAM bridge
 func SetHost(s string) func(*Client) error {
@@ -180,7 +178,6 @@ func SetOutQuantity(u uint) func(*Client) error {
 	}
 }
 
-
 //SetInBackups sets the inbound tunnel backups
 func SetInBackups(u uint) func(*Client) error {
 	return func(c *Client) error {
@@ -204,7 +201,6 @@ func SetOutBackups(u uint) func(*Client) error {
 		}
 	}
 }
-
 
 //SetUnpublish tells the router to not publish the client leaseset
 func SetUnpublished(b bool) func(*Client) error {

--- a/options.go
+++ b/options.go
@@ -1,0 +1,103 @@
+package goSam
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type Option func(*Client) error
+
+func SetAddr(s ...interface{}) func(*Client) error {
+	return func(c *Client) error {
+		if len(s) == 1 {
+			switch v := s[0].(type) {
+			case string:
+				split := strings.SplitN(v, ":", 2)
+				if len(split) == 2 {
+					if i, err := strconv.Atoi(split[1]); err == nil {
+						if i < 65536 {
+							c.addr = split[0]
+							c.port = split[1]
+						} else {
+							return fmt.Errorf("Invalid port")
+						}
+					} else {
+						return fmt.Errorf("Invalid port; non-number")
+					}
+				} else {
+					return fmt.Errorf("Invalid address; use host:port", split)
+				}
+			default:
+				return fmt.Errorf("Invalid address; address must be string")
+			}
+		} else if len(s) == 2 {
+			switch v := s[1].(type) {
+			case int:
+				if v < 65536 {
+					c.addr = s[0].(string)
+					c.port = strconv.Itoa(v)
+				} else {
+					return fmt.Errorf("Invalid port")
+				}
+			case string:
+				if i, err := strconv.Atoi(s[1].(string)); err == nil {
+					if i < 65536 {
+						c.addr = s[0].(string)
+						c.port = s[1].(string)
+					} else {
+						return fmt.Errorf("Invalid port")
+					}
+				} else {
+					return fmt.Errorf("Invalid port; non-number")
+				}
+			default:
+				return fmt.Errorf("Invalid port; non-number")
+			}
+		} else {
+			return fmt.Errorf("Invalid address")
+		}
+		return nil
+	}
+}
+
+func SetHost(s string) func(*Client) error {
+	return func(c *Client) error {
+		c.addr = s
+		return nil
+	}
+}
+
+func SetPort(s interface{}) func(*Client) error {
+	return func(c *Client) error {
+		switch v := s.(type) {
+		case string:
+			port, err := strconv.Atoi(v)
+			if err != nil {
+				return fmt.Errorf("Invalid port; non-number")
+			}
+			if port < 65536 && port > -1 {
+				c.port = v
+				return nil
+			} else {
+				return fmt.Errorf("Invalid port")
+			}
+		case int:
+			if v < 65536 && v > -1 {
+				c.port = strconv.Itoa(v)
+				return nil
+			} else {
+				return fmt.Errorf("Invalid port")
+			}
+		default:
+			return fmt.Errorf("Invalid port")
+		}
+	}
+}
+
+func SetDebug(b bool) func(*Client) error {
+	return func(c *Client) error {
+		c.debug = b
+		return nil
+	}
+}

--- a/options.go
+++ b/options.go
@@ -38,18 +38,16 @@ func SetAddr(s ...interface{}) func(*Client) error {
 					c.addr = s[0].(string)
 					c.port = strconv.Itoa(v)
 					return nil
-				} else {
-					return fmt.Errorf("Invalid port")
 				}
+				return fmt.Errorf("Invalid port")
 			case string:
 				if i, err := strconv.Atoi(s[1].(string)); err == nil {
 					if i < 65536 {
 						c.addr = s[0].(string)
 						c.port = s[1].(string)
 						return nil
-					} else {
-						return fmt.Errorf("Invalid port")
 					}
+					return fmt.Errorf("Invalid port")
 				}
 				return fmt.Errorf("Invalid port; non-number")
 			default:
@@ -191,7 +189,7 @@ func SetOutBackups(u uint) func(*Client) error {
 	}
 }
 
-//SetUnpublish tells the router to not publish the client leaseset
+//SetUnpublished tells the router to not publish the client leaseset
 func SetUnpublished(b bool) func(*Client) error {
 	return func(c *Client) error {
 		c.dontPublishLease = b
@@ -250,17 +248,15 @@ func (c *Client) outbackups() string {
 func (c *Client) encryptlease() string {
 	if c.encryptLease {
 		return "i2cp.encryptLeaseSet=true"
-	} else {
-		return "i2cp.encryptLeaseSet=false"
 	}
+	return "i2cp.encryptLeaseSet=false"
 }
 
 func (c *Client) dontpublishlease() string {
 	if c.dontPublishLease {
 		return "i2cp.dontPublishLeaseSet=true"
-	} else {
-		return "i2cp.dontPublishLeaseSet=false"
 	}
+	return "i2cp.dontPublishLeaseSet=false"
 }
 
 //return all options as string array ready for passing to sendcmd

--- a/options.go
+++ b/options.go
@@ -8,6 +8,8 @@ import (
 
 type Option func(*Client) error
 
+
+//SetAddr sets a clients's address in the form host:port or host, port
 func SetAddr(s ...interface{}) func(*Client) error {
 	return func(c *Client) error {
 		if len(s) == 1 {
@@ -61,6 +63,8 @@ func SetAddr(s ...interface{}) func(*Client) error {
 	}
 }
 
+
+//SetHost sets the host of the client's SAM bridge
 func SetHost(s string) func(*Client) error {
 	return func(c *Client) error {
 		c.addr = s
@@ -68,6 +72,7 @@ func SetHost(s string) func(*Client) error {
 	}
 }
 
+//SetPort sets the port of the client's SAM bridge
 func SetPort(s interface{}) func(*Client) error {
 	return func(c *Client) error {
 		switch v := s.(type) {
@@ -95,6 +100,7 @@ func SetPort(s interface{}) func(*Client) error {
 	}
 }
 
+//SetDebug enables debugging messages
 func SetDebug(b bool) func(*Client) error {
 	return func(c *Client) error {
 		c.debug = b
@@ -102,6 +108,7 @@ func SetDebug(b bool) func(*Client) error {
 	}
 }
 
+//SetInLength sets the number of hops inbound
 func SetInLength(u uint) func(*Client) error {
 	return func(c *Client) error {
 		if u < 7 {
@@ -113,6 +120,7 @@ func SetInLength(u uint) func(*Client) error {
 	}
 }
 
+//SetOutLength sets the number of hops outbound
 func SetOutLength(u uint) func(*Client) error {
 	return func(c *Client) error {
 		if u < 7 {
@@ -124,6 +132,7 @@ func SetOutLength(u uint) func(*Client) error {
 	}
 }
 
+//SetInVariance sets the variance of a number of hops inbound
 func SetInVariance(i int) func(*Client) error {
 	return func(c *Client) error {
 		if i < 7 && i > -7 {
@@ -135,6 +144,7 @@ func SetInVariance(i int) func(*Client) error {
 	}
 }
 
+//SetOutVariance sets the variance of a number of hops outbound
 func SetOutVariance(i int) func(*Client) error {
 	return func(c *Client) error {
 		if i < 7 && i > -7 {
@@ -146,6 +156,7 @@ func SetOutVariance(i int) func(*Client) error {
 	}
 }
 
+//SetInQuantity sets the inbound tunnel quantity
 func SetInQuantity(u uint) func(*Client) error {
 	return func(c *Client) error {
 		if u <= 16 {
@@ -157,6 +168,7 @@ func SetInQuantity(u uint) func(*Client) error {
 	}
 }
 
+//SetOutQuantity sets the outbound tunnel quantity
 func SetOutQuantity(u uint) func(*Client) error {
 	return func(c *Client) error {
 		if u <= 16 {
@@ -168,6 +180,8 @@ func SetOutQuantity(u uint) func(*Client) error {
 	}
 }
 
+
+//SetInBackups sets the inbound tunnel backups
 func SetInBackups(u uint) func(*Client) error {
 	return func(c *Client) error {
 		if u < 6 {
@@ -179,6 +193,7 @@ func SetInBackups(u uint) func(*Client) error {
 	}
 }
 
+//SetOutBackups sets the inbound tunnel backups
 func SetOutBackups(u uint) func(*Client) error {
 	return func(c *Client) error {
 		if u < 6 {
@@ -190,6 +205,8 @@ func SetOutBackups(u uint) func(*Client) error {
 	}
 }
 
+
+//SetUnpublish tells the router to not publish the client leaseset
 func SetUnpublished(b bool) func(*Client) error {
 	return func(c *Client) error {
 		c.dontPublishLease = b
@@ -197,6 +214,7 @@ func SetUnpublished(b bool) func(*Client) error {
 	}
 }
 
+//SetEncrypt tells the router to use an encrypted leaseset
 func SetEncrypt(b bool) func(*Client) error {
 	return func(c *Client) error {
 		c.encryptLease = b

--- a/options.go
+++ b/options.go
@@ -168,6 +168,28 @@ func SetOutQuantity(u uint) func(*Client) error {
 	}
 }
 
+func SetInBackups(u uint) func(*Client) error {
+	return func(c *Client) error {
+		if u < 6 {
+			c.inBackups = u
+			return nil
+		} else {
+			return fmt.Errorf("Invalid inbound tunnel backup quantity")
+		}
+	}
+}
+
+func SetOutBackups(u uint) func(*Client) error {
+	return func(c *Client) error {
+		if u < 6 {
+			c.outBackups = u
+			return nil
+		} else {
+			return fmt.Errorf("Invalid outbound tunnel backup quantity")
+		}
+	}
+}
+
 //return the inbound length as a string.
 func (c *Client) inlength() string {
 	return "inbound.length=" + fmt.Sprint(c.inLength)
@@ -198,6 +220,16 @@ func (c *Client) outquantity() string {
 	return "outbound.quantity=" + fmt.Sprint(c.outQuantity)
 }
 
+//return the inbound tunnel quantity as a string.
+func (c *Client) inbackups() string {
+	return "inbound.backupQuantity=" + fmt.Sprint(c.inQuantity)
+}
+
+//return the outbound tunnel quantity as a string.
+func (c *Client) outbackups() string {
+	return "outbound.backupQuantity=" + fmt.Sprint(c.outQuantity)
+}
+
 //return all options as string array ready for passing to sendcmd
 func (c *Client) allOptions() []string {
 	var options []string
@@ -207,5 +239,7 @@ func (c *Client) allOptions() []string {
 	options = append(options, c.outvariance())
     options = append(options, c.inquantity())
 	options = append(options, c.outquantity())
+    options = append(options, c.inbackups())
+	options = append(options, c.outbackups())
 	return options
 }

--- a/options.go
+++ b/options.go
@@ -101,3 +101,44 @@ func SetDebug(b bool) func(*Client) error {
 		return nil
 	}
 }
+
+func SetInLength(u uint) func(*Client) error {
+	return func(c *Client) error {
+		if u < 7 {
+			c.inLength = u
+			return nil
+		} else {
+			return fmt.Errorf("Invalid inbound tunnel length")
+		}
+	}
+}
+
+func SetOutLength(u uint) func(*Client) error {
+	return func(c *Client) error {
+		if u < 7 {
+			c.outLength = u
+			return nil
+		} else {
+			return fmt.Errorf("Invalid outbound tunnel length")
+		}
+	}
+}
+
+//return the inbound length as a string.
+func (c *Client) inlength() string {
+	return "inbound.length=" + fmt.Sprint(c.inLength)
+}
+
+//return the outbound length as a string.
+func (c *Client) outlength() string {
+	return "outbound.length=" + fmt.Sprint(c.outLength)
+}
+
+//return all options as string array ready for passing to sendcmd
+func (c *Client) allOptions() []string {
+	var options []string
+	options = append(options, c.inlength())
+	options = append(options, c.outlength())
+	return options
+}
+

--- a/options.go
+++ b/options.go
@@ -190,6 +190,20 @@ func SetOutBackups(u uint) func(*Client) error {
 	}
 }
 
+func SetUnpublished(b bool) func(*Client) error {
+	return func(c *Client) error {
+		c.dontPublishLease = b
+		return nil
+	}
+}
+
+func SetEncrypt(b bool) func(*Client) error {
+	return func(c *Client) error {
+		c.encryptLease = b
+		return nil
+	}
+}
+
 //return the inbound length as a string.
 func (c *Client) inlength() string {
 	return "inbound.length=" + fmt.Sprint(c.inLength)
@@ -230,6 +244,22 @@ func (c *Client) outbackups() string {
 	return "outbound.backupQuantity=" + fmt.Sprint(c.outQuantity)
 }
 
+func (c *Client) encryptlease() string {
+	if c.encryptLease {
+		return "i2cp.encryptLeaseSet=true"
+	} else {
+		return "i2cp.encryptLeaseSet=false"
+	}
+}
+
+func (c *Client) dontpublishlease() string {
+	if c.dontPublishLease {
+		return "i2cp.dontPublishLeaseSet=true"
+	} else {
+		return "i2cp.dontPublishLeaseSet=false"
+	}
+}
+
 //return all options as string array ready for passing to sendcmd
 func (c *Client) allOptions() []string {
 	var options []string
@@ -241,5 +271,7 @@ func (c *Client) allOptions() []string {
 	options = append(options, c.outquantity())
     options = append(options, c.inbackups())
 	options = append(options, c.outbackups())
+    options = append(options, c.dontpublishlease())
+	options = append(options, c.encryptlease())
 	return options
 }

--- a/options.go
+++ b/options.go
@@ -42,18 +42,15 @@ func SetAddr(s ...string) func(*Client) error {
 	}
 }
 
-//SetAddrMixed sets a clients's address in the form host:port or host, port
+//SetAddrMixed sets a clients's address in the form host, port(int)
 func SetAddrMixed(s string, i int) func(*Client) error {
 	return func(c *Client) error {
-		if i, err := strconv.Atoi(s); err == nil {
-			if i < 65536 {
-				c.addr = s
-				c.port = strconv.Itoa(i)
-				return nil
-			}
-			return fmt.Errorf("Invalid port")
+		if i < 65536 && i > 0 {
+			c.addr = s
+			c.port = strconv.Itoa(i)
+			return nil
 		}
-		return fmt.Errorf("Invalid port; non-number")
+		return fmt.Errorf("Invalid port")
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -148,7 +148,7 @@ func SetOutVariance(i int) func(*Client) error {
 
 func SetInQuantity(u uint) func(*Client) error {
 	return func(c *Client) error {
-		if u < 16 {
+		if u <= 16 {
 			c.inQuantity = u
 			return nil
 		} else {
@@ -159,7 +159,7 @@ func SetInQuantity(u uint) func(*Client) error {
 
 func SetOutQuantity(u uint) func(*Client) error {
 	return func(c *Client) error {
-		if u < 16 {
+		if u <= 16 {
 			c.outQuantity = u
 			return nil
 		} else {

--- a/options.go
+++ b/options.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 )
 
+//Option is a client Option
 type Option func(*Client) error
 
 //SetAddr sets a clients's address in the form host:port or host, port
@@ -20,15 +21,13 @@ func SetAddr(s ...interface{}) func(*Client) error {
 						if i < 65536 {
 							c.addr = split[0]
 							c.port = split[1]
-						} else {
-							return fmt.Errorf("Invalid port")
+							return nil
 						}
-					} else {
-						return fmt.Errorf("Invalid port; non-number")
+						return fmt.Errorf("Invalid port")
 					}
-				} else {
-					return fmt.Errorf("Invalid address; use host:port", split)
+					return fmt.Errorf("Invalid port; non-number")
 				}
+				return fmt.Errorf("Invalid address; use host:port", split)
 			default:
 				return fmt.Errorf("Invalid address; address must be string")
 			}
@@ -38,6 +37,7 @@ func SetAddr(s ...interface{}) func(*Client) error {
 				if v < 65536 {
 					c.addr = s[0].(string)
 					c.port = strconv.Itoa(v)
+					return nil
 				} else {
 					return fmt.Errorf("Invalid port")
 				}
@@ -46,19 +46,18 @@ func SetAddr(s ...interface{}) func(*Client) error {
 					if i < 65536 {
 						c.addr = s[0].(string)
 						c.port = s[1].(string)
+						return nil
 					} else {
 						return fmt.Errorf("Invalid port")
 					}
-				} else {
-					return fmt.Errorf("Invalid port; non-number")
 				}
+				return fmt.Errorf("Invalid port; non-number")
 			default:
 				return fmt.Errorf("Invalid port; non-number")
 			}
 		} else {
 			return fmt.Errorf("Invalid address")
 		}
-		return nil
 	}
 }
 
@@ -82,16 +81,14 @@ func SetPort(s interface{}) func(*Client) error {
 			if port < 65536 && port > -1 {
 				c.port = v
 				return nil
-			} else {
-				return fmt.Errorf("Invalid port")
 			}
+			return fmt.Errorf("Invalid port")
 		case int:
 			if v < 65536 && v > -1 {
 				c.port = strconv.Itoa(v)
 				return nil
-			} else {
-				return fmt.Errorf("Invalid port")
 			}
+			return fmt.Errorf("Invalid port")
 		default:
 			return fmt.Errorf("Invalid port")
 		}
@@ -112,9 +109,8 @@ func SetInLength(u uint) func(*Client) error {
 		if u < 7 {
 			c.inLength = u
 			return nil
-		} else {
-			return fmt.Errorf("Invalid inbound tunnel length")
 		}
+		return fmt.Errorf("Invalid inbound tunnel length")
 	}
 }
 
@@ -124,9 +120,8 @@ func SetOutLength(u uint) func(*Client) error {
 		if u < 7 {
 			c.outLength = u
 			return nil
-		} else {
-			return fmt.Errorf("Invalid outbound tunnel length")
 		}
+		return fmt.Errorf("Invalid outbound tunnel length")
 	}
 }
 
@@ -136,9 +131,8 @@ func SetInVariance(i int) func(*Client) error {
 		if i < 7 && i > -7 {
 			c.inVariance = i
 			return nil
-		} else {
-			return fmt.Errorf("Invalid inbound tunnel length")
 		}
+		return fmt.Errorf("Invalid inbound tunnel length")
 	}
 }
 
@@ -148,9 +142,8 @@ func SetOutVariance(i int) func(*Client) error {
 		if i < 7 && i > -7 {
 			c.outVariance = i
 			return nil
-		} else {
-			return fmt.Errorf("Invalid outbound tunnel variance")
 		}
+		return fmt.Errorf("Invalid outbound tunnel variance")
 	}
 }
 
@@ -160,9 +153,8 @@ func SetInQuantity(u uint) func(*Client) error {
 		if u <= 16 {
 			c.inQuantity = u
 			return nil
-		} else {
-			return fmt.Errorf("Invalid inbound tunnel quantity")
 		}
+		return fmt.Errorf("Invalid inbound tunnel quantity")
 	}
 }
 
@@ -172,9 +164,8 @@ func SetOutQuantity(u uint) func(*Client) error {
 		if u <= 16 {
 			c.outQuantity = u
 			return nil
-		} else {
-			return fmt.Errorf("Invalid outbound tunnel quantity")
 		}
+		return fmt.Errorf("Invalid outbound tunnel quantity")
 	}
 }
 
@@ -184,9 +175,8 @@ func SetInBackups(u uint) func(*Client) error {
 		if u < 6 {
 			c.inBackups = u
 			return nil
-		} else {
-			return fmt.Errorf("Invalid inbound tunnel backup quantity")
 		}
+		return fmt.Errorf("Invalid inbound tunnel backup quantity")
 	}
 }
 
@@ -196,9 +186,8 @@ func SetOutBackups(u uint) func(*Client) error {
 		if u < 6 {
 			c.outBackups = u
 			return nil
-		} else {
-			return fmt.Errorf("Invalid outbound tunnel backup quantity")
 		}
+		return fmt.Errorf("Invalid outbound tunnel backup quantity")
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -146,6 +146,28 @@ func SetOutVariance(i int) func(*Client) error {
 	}
 }
 
+func SetInQuantity(u uint) func(*Client) error {
+	return func(c *Client) error {
+		if u < 16 {
+			c.inQuantity = u
+			return nil
+		} else {
+			return fmt.Errorf("Invalid inbound tunnel quantity")
+		}
+	}
+}
+
+func SetOutQuantity(u uint) func(*Client) error {
+	return func(c *Client) error {
+		if u < 16 {
+			c.outQuantity = u
+			return nil
+		} else {
+			return fmt.Errorf("Invalid outbound tunnel quantity")
+		}
+	}
+}
+
 //return the inbound length as a string.
 func (c *Client) inlength() string {
 	return "inbound.length=" + fmt.Sprint(c.inLength)
@@ -166,6 +188,16 @@ func (c *Client) outvariance() string {
 	return "outbound.lengthVariance=" + fmt.Sprint(c.outVariance)
 }
 
+//return the inbound tunnel quantity as a string.
+func (c *Client) inquantity() string {
+	return "inbound.quantity=" + fmt.Sprint(c.inQuantity)
+}
+
+//return the outbound tunnel quantity as a string.
+func (c *Client) outquantity() string {
+	return "outbound.quantity=" + fmt.Sprint(c.outQuantity)
+}
+
 //return all options as string array ready for passing to sendcmd
 func (c *Client) allOptions() []string {
 	var options []string
@@ -173,5 +205,7 @@ func (c *Client) allOptions() []string {
 	options = append(options, c.outlength())
     options = append(options, c.invariance())
 	options = append(options, c.outvariance())
+    options = append(options, c.inquantity())
+	options = append(options, c.outquantity())
 	return options
 }

--- a/options_test.go
+++ b/options_test.go
@@ -33,7 +33,7 @@ func TestOptionAddrSlice(t *testing.T) {
 }
 
 func TestOptionAddrMixedSlice(t *testing.T) {
-	client, err := NewClientFromOptions(SetAddr("127.0.0.1", 7656), SetDebug(true))
+	client, err := NewClientFromOptions(SetAddrMixed("127.0.0.1", 7656), SetDebug(true))
 	if err != nil {
 		t.Fatalf("NewDefaultClient() Error: %q\n", err)
 	}
@@ -63,7 +63,7 @@ func TestOptionPort(t *testing.T) {
 }
 
 func TestOptionPortInt(t *testing.T) {
-	client, err := NewClientFromOptions(SetPort(7656), SetDebug(true))
+	client, err := NewClientFromOptions(SetPortInt(7656), SetDebug(true))
 	if err != nil {
 		t.Fatalf("NewDefaultClient() Error: %q\n", err)
 	}

--- a/options_test.go
+++ b/options_test.go
@@ -81,3 +81,25 @@ func TestOptionDebug(t *testing.T) {
 		t.Fatalf("client.Close() Error: %q\n", err)
 	}
 }
+
+func TestOptionInLength(t *testing.T) {
+	client, err := NewClientFromOptions(SetInLength(3), SetDebug(true))
+	client.inlength()
+	if err != nil {
+		t.Fatalf("NewDefaultClient() Error: %q\n", err)
+	}
+	if err := client.Close(); err != nil {
+		t.Fatalf("client.Close() Error: %q\n", err)
+	}
+}
+
+func TestOptionOutLength(t *testing.T) {
+	client, err := NewClientFromOptions(SetInLength(3), SetDebug(true))
+	client.outlength()
+	if err != nil {
+		t.Fatalf("NewDefaultClient() Error: %q\n", err)
+	}
+	if err := client.Close(); err != nil {
+		t.Fatalf("client.Close() Error: %q\n", err)
+	}
+}

--- a/options_test.go
+++ b/options_test.go
@@ -170,3 +170,23 @@ func TestOptionOutBackups(t *testing.T) {
 		t.Fatalf("client.Close() Error: %q\n", err)
 	}
 }
+
+func TestOptionEncryptLease(t *testing.T) {
+	client, err := NewClientFromOptions(SetEncrypt(true), SetDebug(true))
+	if err != nil {
+		t.Fatalf("NewDefaultClient() Error: %q\n", err)
+	}
+	if err := client.Close(); err != nil {
+		t.Fatalf("client.Close() Error: %q\n", err)
+	}
+}
+
+func TestOptionUnpublishedLease(t *testing.T) {
+	client, err := NewClientFromOptions(SetUnpublished(true), SetDebug(true))
+	if err != nil {
+		t.Fatalf("NewDefaultClient() Error: %q\n", err)
+	}
+	if err := client.Close(); err != nil {
+		t.Fatalf("client.Close() Error: %q\n", err)
+	}
+}

--- a/options_test.go
+++ b/options_test.go
@@ -103,3 +103,25 @@ func TestOptionOutLength(t *testing.T) {
 		t.Fatalf("client.Close() Error: %q\n", err)
 	}
 }
+
+func TestOptionInVariance(t *testing.T) {
+	client, err := NewClientFromOptions(SetInVariance(1), SetDebug(true))
+	client.invariance()
+	if err != nil {
+		t.Fatalf("NewDefaultClient() Error: %q\n", err)
+	}
+	if err := client.Close(); err != nil {
+		t.Fatalf("client.Close() Error: %q\n", err)
+	}
+}
+
+func TestOptionOutVariance(t *testing.T) {
+	client, err := NewClientFromOptions(SetOutVariance(1), SetDebug(true))
+	client.outvariance()
+	if err != nil {
+		t.Fatalf("NewDefaultClient() Error: %q\n", err)
+	}
+	if err := client.Close(); err != nil {
+		t.Fatalf("client.Close() Error: %q\n", err)
+	}
+}

--- a/options_test.go
+++ b/options_test.go
@@ -148,3 +148,25 @@ func TestOptionOutQuantity(t *testing.T) {
 		t.Fatalf("client.Close() Error: %q\n", err)
 	}
 }
+
+func TestOptionInBackups(t *testing.T) {
+	client, err := NewClientFromOptions(SetInBackups(5), SetDebug(true))
+	client.inbackups()
+	if err != nil {
+		t.Fatalf("NewDefaultClient() Error: %q\n", err)
+	}
+	if err := client.Close(); err != nil {
+		t.Fatalf("client.Close() Error: %q\n", err)
+	}
+}
+
+func TestOptionOutBackups(t *testing.T) {
+	client, err := NewClientFromOptions(SetOutBackups(5), SetDebug(true))
+	client.outbackups()
+	if err != nil {
+		t.Fatalf("NewDefaultClient() Error: %q\n", err)
+	}
+	if err := client.Close(); err != nil {
+		t.Fatalf("client.Close() Error: %q\n", err)
+	}
+}

--- a/options_test.go
+++ b/options_test.go
@@ -126,7 +126,6 @@ func TestOptionOutVariance(t *testing.T) {
 	}
 }
 
-
 func TestOptionInQuantity(t *testing.T) {
 	client, err := NewClientFromOptions(SetInQuantity(6), SetDebug(true))
 	client.inquantity()

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,83 @@
+package goSam
+
+import "testing"
+
+func TestOptionAddrString(t *testing.T) {
+	client, err := NewClientFromOptions(SetAddr("127.0.0.1:7656"), SetDebug(true))
+	if err != nil {
+		t.Fatalf("NewDefaultClient() Error: %q\n", err)
+	}
+	if err := client.Close(); err != nil {
+		t.Fatalf("client.Close() Error: %q\n", err)
+	}
+}
+
+func TestOptionAddrStringLh(t *testing.T) {
+	client, err := NewClientFromOptions(SetAddr("localhost:7656"), SetDebug(true))
+	if err != nil {
+		t.Fatalf("NewDefaultClient() Error: %q\n", err)
+	}
+	if err := client.Close(); err != nil {
+		t.Fatalf("client.Close() Error: %q\n", err)
+	}
+}
+
+func TestOptionAddrSlice(t *testing.T) {
+	client, err := NewClientFromOptions(SetAddr("127.0.0.1", "7656"), SetDebug(true))
+	if err != nil {
+		t.Fatalf("NewDefaultClient() Error: %q\n", err)
+	}
+	if err := client.Close(); err != nil {
+		t.Fatalf("client.Close() Error: %q\n", err)
+	}
+}
+
+func TestOptionAddrMixedSlice(t *testing.T) {
+	client, err := NewClientFromOptions(SetAddr("127.0.0.1", 7656), SetDebug(true))
+	if err != nil {
+		t.Fatalf("NewDefaultClient() Error: %q\n", err)
+	}
+	if err := client.Close(); err != nil {
+		t.Fatalf("client.Close() Error: %q\n", err)
+	}
+}
+
+func TestOptionHost(t *testing.T) {
+	client, err := NewClientFromOptions(SetHost("127.0.0.1"), SetDebug(true))
+	if err != nil {
+		t.Fatalf("NewDefaultClient() Error: %q\n", err)
+	}
+	if err := client.Close(); err != nil {
+		t.Fatalf("client.Close() Error: %q\n", err)
+	}
+}
+
+func TestOptionPort(t *testing.T) {
+	client, err := NewClientFromOptions(SetPort("7656"), SetDebug(true))
+	if err != nil {
+		t.Fatalf("NewDefaultClient() Error: %q\n", err)
+	}
+	if err := client.Close(); err != nil {
+		t.Fatalf("client.Close() Error: %q\n", err)
+	}
+}
+
+func TestOptionPortInt(t *testing.T) {
+	client, err := NewClientFromOptions(SetPort(7656), SetDebug(true))
+	if err != nil {
+		t.Fatalf("NewDefaultClient() Error: %q\n", err)
+	}
+	if err := client.Close(); err != nil {
+		t.Fatalf("client.Close() Error: %q\n", err)
+	}
+}
+
+func TestOptionDebug(t *testing.T) {
+	client, err := NewClientFromOptions(SetDebug(true))
+	if err != nil {
+		t.Fatalf("NewDefaultClient() Error: %q\n", err)
+	}
+	if err := client.Close(); err != nil {
+		t.Fatalf("client.Close() Error: %q\n", err)
+	}
+}

--- a/options_test.go
+++ b/options_test.go
@@ -125,3 +125,26 @@ func TestOptionOutVariance(t *testing.T) {
 		t.Fatalf("client.Close() Error: %q\n", err)
 	}
 }
+
+
+func TestOptionInQuantity(t *testing.T) {
+	client, err := NewClientFromOptions(SetInQuantity(6), SetDebug(true))
+	client.inquantity()
+	if err != nil {
+		t.Fatalf("NewDefaultClient() Error: %q\n", err)
+	}
+	if err := client.Close(); err != nil {
+		t.Fatalf("client.Close() Error: %q\n", err)
+	}
+}
+
+func TestOptionOutQuantity(t *testing.T) {
+	client, err := NewClientFromOptions(SetOutQuantity(6), SetDebug(true))
+	client.outquantity()
+	if err != nil {
+		t.Fatalf("NewDefaultClient() Error: %q\n", err)
+	}
+	if err := client.Close(); err != nil {
+		t.Fatalf("client.Close() Error: %q\n", err)
+	}
+}

--- a/replyParser.go
+++ b/replyParser.go
@@ -50,7 +50,8 @@ func parseReply(line string) (*Reply, error) {
 	}
 
 	for _, v := range parts[2:] {
-		kvPair := strings.Split(v, "=")
+        kvPair := strings.Split(strings.Replace(v, "==", "%", -1), "=")
+        kvPair[1] = strings.Replace(kvPair[1], "%", "==", -1)
 		if len(kvPair) != 2 {
 			return nil, fmt.Errorf("Malformed key-value-pair.\n%s\n", kvPair)
 		}

--- a/replyParser.go
+++ b/replyParser.go
@@ -50,8 +50,7 @@ func parseReply(line string) (*Reply, error) {
 	}
 
 	for _, v := range parts[2:] {
-        kvPair := strings.Split(strings.Replace(v, "==", "%", -1), "=")
-        kvPair[1] = strings.Replace(kvPair[1], "%", "==", -1)
+		kvPair := strings.SplitN(v, "=", 2)
 		if len(kvPair) != 2 {
 			return nil, fmt.Errorf("Malformed key-value-pair.\n%s\n", kvPair)
 		}

--- a/replyParser.go
+++ b/replyParser.go
@@ -51,9 +51,12 @@ func parseReply(line string) (*Reply, error) {
 
 	for _, v := range parts[2:] {
 		kvPair := strings.SplitN(v, "=", 2)
-		if len(kvPair) != 2 {
-			return nil, fmt.Errorf("Malformed key-value-pair.\n%s\n", kvPair)
+		if kvPair != nil {
+			if len(kvPair) != 2 {
+				return nil, fmt.Errorf("Malformed key-value-pair.\n%s\n", kvPair)
+			}
 		}
+
 		r.Pairs[kvPair[0]] = kvPair[1]
 	}
 

--- a/replyParser_test.go
+++ b/replyParser_test.go
@@ -33,6 +33,19 @@ var validCases = []struct {
 			},
 		},
 	},
+	// result of a b32.i2p naming lookup
+	{
+		"NAMING REPLY RESULT=OK NAME=gkso46tc47hdua2kva5zahj3unmyh6ia7bv5oc2ybn2hmeowpz7a.b32.i2p VALUE=mlHQraXLpcE7A4MVeVniRHM~2yoaW1fOYVKj3ZiNTe4UPIAlIReYUMHSnZnloFWX7bh2OoEg08JBGoSQPtGkCZjqSBmfeDdMqtwbZ~~sok-jNo4e5rWnfCOHYYPVcuE8jB~7M5ioJzk8QZRqh3AjCQsKBUZgTzUfGlP12j3GtAf5C9iAGxTTB1sGE96752EKP0dzyGOs4NAujwkgm6NzVoqlkXD~fognUrQOeG~~OqChsAeqIRqj40FsJmsJREmZ4GhjFAqzLUQ4hMpKSbqMI~wtfjeNs-WKtM7pCD09uwSmYwW84wu-WxLGZiIt2GKmbPv~JrqYFNv9EM0SzUonAF8pw9GAhUn8-26kkgCXTs05Kut7NuQHghu3jHfS-frlPmAt-Uu5T4ZcLiHiFrnG2lYTtjxBFXh7W72IBncHSixhVhd4lYM7REKFj7G~5ttW9EBeL1unbNYWiQOEQjtGlmwxYt~~2EV16w339aQQ~S~69-tS6vFA1n2DgkMdg06pBQAEAAEAAA==\n",
+		Reply{
+			Topic: "NAMING",
+			Type:  "REPLY",
+			Pairs: map[string]string{
+				"RESULT": "OK",
+				"NAME":   "gkso46tc47hdua2kva5zahj3unmyh6ia7bv5oc2ybn2hmeowpz7a.b32.i2p",
+				"VALUE":  "mlHQraXLpcE7A4MVeVniRHM~2yoaW1fOYVKj3ZiNTe4UPIAlIReYUMHSnZnloFWX7bh2OoEg08JBGoSQPtGkCZjqSBmfeDdMqtwbZ~~sok-jNo4e5rWnfCOHYYPVcuE8jB~7M5ioJzk8QZRqh3AjCQsKBUZgTzUfGlP12j3GtAf5C9iAGxTTB1sGE96752EKP0dzyGOs4NAujwkgm6NzVoqlkXD~fognUrQOeG~~OqChsAeqIRqj40FsJmsJREmZ4GhjFAqzLUQ4hMpKSbqMI~wtfjeNs-WKtM7pCD09uwSmYwW84wu-WxLGZiIt2GKmbPv~JrqYFNv9EM0SzUonAF8pw9GAhUn8-26kkgCXTs05Kut7NuQHghu3jHfS-frlPmAt-Uu5T4ZcLiHiFrnG2lYTtjxBFXh7W72IBncHSixhVhd4lYM7REKFj7G~5ttW9EBeL1unbNYWiQOEQjtGlmwxYt~~2EV16w339aQQ~S~69-tS6vFA1n2DgkMdg06pBQAEAAEAAA==",
+			},
+		},
+	},
 	// session status reply
 	{
 		"SESSION STATUS RESULT=I2P_ERROR MESSAGE=TheMessageFromI2p\n",

--- a/sessions.go
+++ b/sessions.go
@@ -19,7 +19,7 @@ func (c *Client) CreateStreamSession(dest string) (int32, string, error) {
 	}
 
 	id := rand.Int31n(math.MaxInt32)
-	r, err := c.sendCmd("SESSION CREATE STYLE=STREAM ID=%d DESTINATION=%s\n", id, dest, c.allOptions())
+	r, err := c.sendCmd("SESSION CREATE STYLE=STREAM ID=%d DESTINATION=%s %s\n", id, dest, c.allOptions())
 	if err != nil {
 		return -1, "", err
 	}

--- a/sessions.go
+++ b/sessions.go
@@ -19,7 +19,7 @@ func (c *Client) CreateStreamSession(dest string) (int32, string, error) {
 	}
 
 	id := rand.Int31n(math.MaxInt32)
-	r, err := c.sendCmd("SESSION CREATE STYLE=STREAM ID=%d DESTINATION=%s\n", id, dest)
+	r, err := c.sendCmd("SESSION CREATE STYLE=STREAM ID=%d DESTINATION=%s\n", id, dest, c.allOptions())
 	if err != nil {
 		return -1, "", err
 	}


### PR DESCRIPTION
Sorry about mangling the history last time I submitted this. I tried to rebase and ended up making it worse. Except for the fact that ports can now be configured by passing an integer or a string, the changes are all the same.